### PR TITLE
Game engine rendering objects

### DIFF
--- a/include/NullGameEngine/Camera.hpp
+++ b/include/NullGameEngine/Camera.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <NullGameEngine.hpp>
+#include <GameObject.hpp>
+
+namespace null {
+
+    class Camera final : public GameObject {
+        public:
+            // for now it's ok to have distance as a public member
+            // later it could be implemented more prettier with
+            // methods that manipulate how the camera moves
+            int distance;
+    };
+
+}
+

--- a/include/NullGameEngine/Camera.hpp
+++ b/include/NullGameEngine/Camera.hpp
@@ -11,10 +11,6 @@ namespace null {
             // later it could be implemented more prettier with
             // methods that manipulate how the camera moves
             int distance;
-
-            // todo fix the nullptr. the camera doesn't have a texture
-            // yet it has coordinates (a transform)
-            Camera() : GameObject(nullptr) { }
     };
 
 }

--- a/include/NullGameEngine/Camera.hpp
+++ b/include/NullGameEngine/Camera.hpp
@@ -11,6 +11,10 @@ namespace null {
             // later it could be implemented more prettier with
             // methods that manipulate how the camera moves
             int distance;
+
+            // todo fix the nullptr. the camera doesn't have a texture
+            // yet it has coordinates (a transform)
+            Camera() : GameObject(nullptr) { }
     };
 
 }

--- a/include/NullGameEngine/GameObject.hpp
+++ b/include/NullGameEngine/GameObject.hpp
@@ -10,7 +10,7 @@
 namespace null {
 
     class GameObject {
-    private:
+    protected:
         bool isVisible;
         std::shared_ptr<sf::Sprite> sprite;
         std::weak_ptr<GameObject> parent;

--- a/include/NullGameEngine/GameObject.hpp
+++ b/include/NullGameEngine/GameObject.hpp
@@ -12,7 +12,7 @@ namespace null {
     class GameObject {
     protected:
         bool isVisible;
-        std::shared_ptr<sf::Sprite> sprite;
+        sf::Sprite sprite;
         std::weak_ptr<GameObject> parent;
         std::vector<std::shared_ptr<GameObject>> children;
         std::set<std::string> tags;
@@ -20,9 +20,9 @@ namespace null {
 
     public:
 
-        GameObject(std::shared_ptr<sf::Sprite>);
+        GameObject();
 
-        std::weak_ptr<sf::Sprite> getSprite();
+        sf::Sprite& getSprite();
 
         bool getIsVisible();
 

--- a/include/NullGameEngine/GameObject.hpp
+++ b/include/NullGameEngine/GameObject.hpp
@@ -20,7 +20,7 @@ namespace null {
 
     public:
 
-        GameObject();
+        GameObject(std::shared_ptr<sf::Sprite>);
 
         std::weak_ptr<sf::Sprite> getSprite();
 

--- a/include/NullGameEngine/GameObject.hpp
+++ b/include/NullGameEngine/GameObject.hpp
@@ -53,7 +53,7 @@ namespace null {
 
         void update();
 
-        void setIsVisible(bool &isVisible);
+        void setIsVisible(bool isVisible);
 
         void addScript(Script &script);
     };

--- a/include/NullGameEngine/MainLoop.hpp
+++ b/include/NullGameEngine/MainLoop.hpp
@@ -1,7 +1,10 @@
+#pragma once
+
 #include <memory>
 
 #include <NullGameEngine.hpp>
 #include <Scene.hpp>
+#include <Renderer.hpp>
 
 namespace null {
 

--- a/include/NullGameEngine/NullGameEngine.hpp
+++ b/include/NullGameEngine/NullGameEngine.hpp
@@ -6,5 +6,7 @@ namespace null {
     class Scene;
     class SceneLoader;
     class MainLoop;
+    class Camera;
+    class Renderer;
 }
 

--- a/include/NullGameEngine/Renderer.hpp
+++ b/include/NullGameEngine/Renderer.hpp
@@ -8,7 +8,7 @@ namespace null {
 
     class Renderer {
         public:
-            static void render(const sf::RenderWindow&, const Scene&);
+            static void render(sf::RenderWindow&, const Scene&);
     };
 
 }

--- a/include/NullGameEngine/Renderer.hpp
+++ b/include/NullGameEngine/Renderer.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+
+#include <NullGameEngine.hpp>
+#include <MainLoop.hpp>
+
+namespace null {
+
+    class Renderer {
+        public:
+            static void render(const sf::RenderWindow&, const Scene&);
+    };
+
+}
+

--- a/include/NullGameEngine/Scene.hpp
+++ b/include/NullGameEngine/Scene.hpp
@@ -2,16 +2,17 @@
 
 #include <NullGameEngine.hpp>
 #include <GameObject.hpp>
+#include <Camera.hpp>
 
 namespace null {
     class Scene{
     private:
-        GameObject rootGameObject;
+        Camera camera;
         std::vector<GameObject> gameObjects;
     public:
         Scene() {
             gameObjects = std::vector<GameObject>();
-            rootGameObject = GameObject();
+            camera = Camera();
         }
 
         void start();
@@ -19,6 +20,8 @@ namespace null {
         void update();
 
         void addGameObject(GameObject &gameObject);
+
+        friend Renderer;
     };
 }
 

--- a/include/NullGameEngine/Scene.hpp
+++ b/include/NullGameEngine/Scene.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include <NullGameEngine.hpp>
 #include <GameObject.hpp>
 #include <Camera.hpp>
@@ -8,10 +10,10 @@ namespace null {
     class Scene{
     private:
         Camera camera;
-        std::vector<GameObject> gameObjects;
+        std::vector<std::unique_ptr<GameObject>> gameObjects;
     public:
         Scene() {
-            gameObjects = std::vector<GameObject>();
+            gameObjects = std::vector<std::unique_ptr<GameObject>>();
             camera = Camera();
         }
 
@@ -19,7 +21,7 @@ namespace null {
 
         void update();
 
-        void addGameObject(GameObject &gameObject);
+        void addGameObject(std::unique_ptr<GameObject>);
 
         friend Renderer;
     };

--- a/src/NullGameEngine/CMakeLists.txt
+++ b/src/NullGameEngine/CMakeLists.txt
@@ -19,6 +19,10 @@ set(SRC
     ${INCROOT}/SceneLoader.hpp
     ${SRCROOT}/MainLoop.cpp
     ${INCROOT}/MainLoop.hpp
+    ${SRCROOT}/Camera.cpp
+    ${INCROOT}/Camera.hpp
+    ${SRCROOT}/Renderer.cpp
+    ${INCROOT}/Renderer.hpp
     )
 
 add_library(nullGameEngine STATIC ${SRC})

--- a/src/NullGameEngine/Camera.cpp
+++ b/src/NullGameEngine/Camera.cpp
@@ -1,0 +1,8 @@
+#include <Camera.hpp>
+
+namespace null {
+
+    // this is for the later implementations of camera motions
+
+}
+

--- a/src/NullGameEngine/GameObject.cpp
+++ b/src/NullGameEngine/GameObject.cpp
@@ -20,7 +20,7 @@ namespace null {
         return this->isVisible;
     }
 
-    void GameObject::setIsVisible(bool &isVisible){
+    void GameObject::setIsVisible(bool isVisible){
         this->isVisible = isVisible;
     }
 

--- a/src/NullGameEngine/GameObject.cpp
+++ b/src/NullGameEngine/GameObject.cpp
@@ -1,10 +1,12 @@
+#include <memory>
+
 #include <GameObject.hpp>
 #include <Script.hpp>
 
 namespace null {
-    GameObject::GameObject():
+    GameObject::GameObject(std::shared_ptr<sf::Sprite> sprite):
     isVisible(false),
-    sprite(nullptr) {
+    sprite(sprite) {
         this->children = std::vector<std::shared_ptr<GameObject>>();
         this->tags = std::set<std::string>();
         this->scripts = std::vector<Script>();

--- a/src/NullGameEngine/GameObject.cpp
+++ b/src/NullGameEngine/GameObject.cpp
@@ -4,16 +4,16 @@
 #include <Script.hpp>
 
 namespace null {
-    GameObject::GameObject(std::shared_ptr<sf::Sprite> sprite):
-    isVisible(false),
-    sprite(sprite) {
+    GameObject::GameObject():
+    isVisible(false) {
         this->children = std::vector<std::shared_ptr<GameObject>>();
         this->tags = std::set<std::string>();
         this->scripts = std::vector<Script>();
+        this->sprite = sf::Sprite();
     }
 
-    std::weak_ptr<sf::Sprite> GameObject::getSprite() {
-        return std::weak_ptr<sf::Sprite>(this->sprite);
+    sf::Sprite& GameObject::getSprite() {
+        return this->sprite;
     }
 
     bool GameObject::getIsVisible() {
@@ -59,19 +59,19 @@ namespace null {
     }
 
     sf::Transform GameObject::getTransform() {
-        return sprite->getTransform();
+        return sprite.getTransform();
     }
 
     sf::Vector2f GameObject::getPosition() {
-        return sprite->getPosition();
+        return sprite.getPosition();
     }
 
     void GameObject::setPosition(float x, float y) {
-        sprite->setPosition(x, y);
+        sprite.setPosition(x, y);
     }
 
     void GameObject::setPosition(sf::Vector2f &pos) {
-        sprite->setPosition(pos);
+        sprite.setPosition(pos);
     }
 
     void GameObject::start() {

--- a/src/NullGameEngine/MainLoop.cpp
+++ b/src/NullGameEngine/MainLoop.cpp
@@ -2,35 +2,27 @@
 
 #include <MainLoop.hpp>
 #include <Scene.hpp>
+#include <Renderer.hpp>
 
 namespace null {
 
     std::unique_ptr<Scene> MainLoop::scene = nullptr;
-
-    static void renderingThread(sf::RenderWindow &window) {
-
-        window.setActive(true);
-        // todo the following code should be a part of the scene
-        sf::Texture nullTexture;
-        if (!nullTexture.loadFromFile("../null.jpg")) {
-            std::terminate();
-        }
-        sf::Sprite nullPicture(nullTexture);
-
-        while (window.isOpen()) {
-            window.clear(sf::Color::Black);
-            // in future, the drawer will be called here and will be passed the scene object
-            window.draw(nullPicture);
-            window.display();
-        }
-
-    }
 
     // todo this is a dummy implementation, copied from the earlier draft
     int MainLoop::run() {
         sf::RenderWindow sfmlWin(sf::VideoMode(1280, 720), "{[Null]}");
 
         sfmlWin.setActive(false);
+
+        auto renderingThread = [](sf::RenderWindow &window) {
+            window.setActive(true);
+            while (window.isOpen()) {
+                window.clear(sf::Color::Black);
+                Renderer::render(window, *MainLoop::scene);
+                window.display();
+            }
+        };
+
         sf::Thread rendererThread(renderingThread, std::ref(sfmlWin));
         rendererThread.launch();
 

--- a/src/NullGameEngine/Renderer.cpp
+++ b/src/NullGameEngine/Renderer.cpp
@@ -8,8 +8,7 @@ namespace null {
 
     void Renderer::render(sf::RenderWindow& window, const Scene& scene) {
         for (const std::unique_ptr<GameObject>& go : scene.gameObjects) {
-            // todo this is ugly
-            sf::Sprite sprite = *(*go).getSprite().lock();
+            sf::Sprite sprite = go->getSprite();
             if (go->getIsVisible()) {
                 window.draw(sprite);
             }

--- a/src/NullGameEngine/Renderer.cpp
+++ b/src/NullGameEngine/Renderer.cpp
@@ -1,0 +1,17 @@
+#include <SFML/Graphics.hpp>
+#include <SFML/Window.hpp>
+
+#include <Renderer.hpp>
+
+namespace null {
+
+    void Renderer::render(const sf::RenderWindow& window, const Scene& scene) {
+        auto gameObjects = scene.gameObjects;
+        for (GameObject& go : gameObjects) {
+            auto sprite = *go.getSprite().lock();
+            window.draw(sprite);
+        }
+    }
+
+}
+

--- a/src/NullGameEngine/Renderer.cpp
+++ b/src/NullGameEngine/Renderer.cpp
@@ -10,7 +10,9 @@ namespace null {
         for (const std::unique_ptr<GameObject>& go : scene.gameObjects) {
             // todo this is ugly
             sf::Sprite sprite = *(*go).getSprite().lock();
-            window.draw(sprite);
+            if (go->getIsVisible()) {
+                window.draw(sprite);
+            }
         }
     }
 

--- a/src/NullGameEngine/Renderer.cpp
+++ b/src/NullGameEngine/Renderer.cpp
@@ -1,14 +1,13 @@
 #include <SFML/Graphics.hpp>
-#include <SFML/Window.hpp>
 
 #include <Renderer.hpp>
 
 namespace null {
 
-    void Renderer::render(const sf::RenderWindow& window, const Scene& scene) {
+    void Renderer::render(sf::RenderWindow& window, const Scene& scene) {
         auto gameObjects = scene.gameObjects;
         for (GameObject& go : gameObjects) {
-            auto sprite = *go.getSprite().lock();
+            sf::Sprite sprite = *go.getSprite().lock();
             window.draw(sprite);
         }
     }

--- a/src/NullGameEngine/Renderer.cpp
+++ b/src/NullGameEngine/Renderer.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <SFML/Graphics.hpp>
 
 #include <Renderer.hpp>
@@ -5,9 +7,9 @@
 namespace null {
 
     void Renderer::render(sf::RenderWindow& window, const Scene& scene) {
-        auto gameObjects = scene.gameObjects;
-        for (GameObject& go : gameObjects) {
-            sf::Sprite sprite = *go.getSprite().lock();
+        for (const std::unique_ptr<GameObject>& go : scene.gameObjects) {
+            // todo this is ugly
+            sf::Sprite sprite = *(*go).getSprite().lock();
             window.draw(sprite);
         }
     }

--- a/src/NullGameEngine/Scene.cpp
+++ b/src/NullGameEngine/Scene.cpp
@@ -1,21 +1,23 @@
+#include <memory>
+
 #include <Scene.hpp>
 
 namespace null
 {
 
-    void Scene::addGameObject(GameObject &gameObject) {
-        gameObjects.push_back(gameObject);
+    void Scene::addGameObject(std::unique_ptr<GameObject> newGameObject) {
+        gameObjects.push_back(move(newGameObject));
     }
 
     void Scene::start() {
         for (auto &obj : gameObjects) {
-            obj.start();
+            obj->start();
         }
     }
 
     void Scene::update() {
         for (auto &obj : gameObjects) {
-            obj.update();
+            obj->update();
         }
     }
 

--- a/src/NullGameEngine/SceneLoader.cpp
+++ b/src/NullGameEngine/SceneLoader.cpp
@@ -18,8 +18,8 @@ namespace null {
         // as the sprite lives. todo manage it with resource manager
         sf::Texture* nullTexture = new sf::Texture();
         nullTexture->loadFromFile("../null.jpg");
-        auto sprite = std::make_shared<sf::Sprite>(*nullTexture);
-        auto nullGameLogo = std::make_unique<GameObject>(sprite);
+        auto nullGameLogo = std::make_unique<GameObject>();
+        nullGameLogo->getSprite().setTexture(*nullTexture);
         nullGameLogo->setIsVisible(true);
         newScene->addGameObject(move(nullGameLogo));
 

--- a/src/NullGameEngine/SceneLoader.cpp
+++ b/src/NullGameEngine/SceneLoader.cpp
@@ -20,6 +20,7 @@ namespace null {
         nullTexture->loadFromFile("../null.jpg");
         auto sprite = std::make_shared<sf::Sprite>(*nullTexture);
         auto nullGameLogo = std::make_unique<GameObject>(sprite);
+        nullGameLogo->setIsVisible(true);
         newScene->addGameObject(move(nullGameLogo));
 
         MainLoop::provideScene(move(newScene));

--- a/src/NullGameEngine/SceneLoader.cpp
+++ b/src/NullGameEngine/SceneLoader.cpp
@@ -7,8 +7,21 @@
 namespace null {
 
     // todo this is a dummy implementation
+    // later reimplement this by loading stuff from file 
+    // and using a resource manager
     void SceneLoader::loadSceneFromFile(std::string) {
+        
+        // todo this should be done in a scene file
         auto newScene = std::make_unique<Scene>();
+
+        // this texture is not released on purpose, because it MUST exist for as long
+        // as the sprite lives. todo manage it with resource manager
+        sf::Texture* nullTexture = new sf::Texture();
+        nullTexture->loadFromFile("../null.jpg");
+        auto sprite = std::make_shared<sf::Sprite>(*nullTexture);
+        auto nullGameLogo = std::make_unique<GameObject>(sprite);
+        newScene->addGameObject(move(nullGameLogo));
+
         MainLoop::provideScene(move(newScene));
     };
 


### PR DESCRIPTION
Отметил private'ы Gameobject'а как protected, чтобы получше унаследовать в Camera. Сделал камеру рутовым gameobject для сцены (причины такие: рутовый объект быть должен, и камера быть где-то должна как объект, почему бы не убить двух зайцев сразу). Gameobject теперь требует Sprite, чтобы его можно было создать. Это исходя из тех соображений, что у объекта должны быть координаты (Transform) (скажем, даже у невидимой камеры), а это находится как раз в Sprite. При этом сам sprite не обязан содержать текстуру, к слову
Камера отличается только тем, что у нее есть distance -- параметр, который будет определять, насколько близко камера к плоскости. Использоваться это будет потом, сейчас ничего не реализовывал по этому поводу

Какие-то из решений в этом пр могут быть сомнительными, поэтому готов побеседовать на эту тему, @p-vasilev 