### PR TITLE
Fix rigidbody freeing

### DIFF
--- a/include/NullGameEngine/GameObject.hpp
+++ b/include/NullGameEngine/GameObject.hpp
@@ -17,6 +17,7 @@ namespace null {
         void assertSpriteHasSize();
         void setRigidBodyDefPositionBySprite(b2BodyDef&);
         void setShapeAsBoxBySprite(b2PolygonShape&);
+        std::weak_ptr<Scene> scene;
     protected:
         sf::Sprite sprite;
         b2Body* rigidBody = nullptr;
@@ -34,6 +35,8 @@ namespace null {
         GameObject();
 
         ~GameObject();
+
+        std::weak_ptr<Scene> getScene();
 
         bool visible;
 

--- a/include/NullGameEngine/MainLoop.hpp
+++ b/include/NullGameEngine/MainLoop.hpp
@@ -10,9 +10,9 @@ namespace null {
 
     class MainLoop {
         private:
-            static std::unique_ptr<Scene> scene;
+            static std::shared_ptr<Scene> scene;
             MainLoop();
-            static void provideScene(std::unique_ptr<Scene> newScene) {
+            static void provideScene(std::shared_ptr<Scene> newScene) {
                 MainLoop::scene = std::move(newScene);
             }
         public:

--- a/include/NullGameEngine/Scene.hpp
+++ b/include/NullGameEngine/Scene.hpp
@@ -17,6 +17,8 @@ namespace null {
     public:
         Scene();
 
+        std::weak_ptr<Scene> self;
+
         void start();
 
         void update();

--- a/include/NullGameEngine/SceneLoader.hpp
+++ b/include/NullGameEngine/SceneLoader.hpp
@@ -10,6 +10,7 @@ namespace null {
 
         public:
             static void loadSceneFromFile(std::filesystem::path);
+            static void changeScene(std::filesystem::path);
 
     };
 

--- a/include/Scripts/ReloadSceneScript.hpp
+++ b/include/Scripts/ReloadSceneScript.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Script.hpp>
+#include <SFML/System.hpp>
+#include <GameObject.hpp>
+
+namespace null {
+
+    class ReloadSceneScript : public Script {
+        
+        public:
+        void start() override;
+
+        void update() override;
+
+        explicit ReloadSceneScript(GameObject& gameObject);
+    };
+
+}
+

--- a/include/Scripts/Scripts.hpp
+++ b/include/Scripts/Scripts.hpp
@@ -3,4 +3,5 @@
 #include <ExampleScript.hpp>
 #include <ClockedScript.hpp>
 #include <ExampleClockedScript.hpp>
+#include <ReloadSceneScript.hpp>
 

--- a/src/NullGameEngine/GameObject.cpp
+++ b/src/NullGameEngine/GameObject.cpp
@@ -15,9 +15,15 @@ namespace null {
     GameObject::GameObject(): visible(false) { };
 
     GameObject::~GameObject() {
-        if (rigidBody) {
-            rigidBody->GetWorld()->DestroyBody(rigidBody);
+        if (scene.lock()) {
+            if (rigidBody) {
+                rigidBody->GetWorld()->DestroyBody(rigidBody);
+            }
         }
+    }
+
+    std::weak_ptr<Scene> GameObject::getScene() {
+        return scene;
     }
 
     sf::Sprite& GameObject::getSprite() {

--- a/src/NullGameEngine/MainLoop.cpp
+++ b/src/NullGameEngine/MainLoop.cpp
@@ -9,7 +9,7 @@ namespace null {
 
     constexpr unsigned int MAX_FRAMERATE = 60;
 
-    std::unique_ptr<Scene> MainLoop::scene = nullptr;
+    std::shared_ptr<Scene> MainLoop::scene = nullptr;
 
     // todo this is a dummy implementation, copied from the earlier draft
     int MainLoop::run() {

--- a/src/NullGameEngine/Scene.cpp
+++ b/src/NullGameEngine/Scene.cpp
@@ -9,6 +9,7 @@ namespace null {
     Scene::Scene() : box2dWorld(b2Vec2(0.0, 9.8f)) { }
 
     void Scene::addGameObject(std::unique_ptr<GameObject> newGameObject) {
+        newGameObject->scene = self;
         gameObjects.push_back(move(newGameObject));
     }
 

--- a/src/NullGameEngine/SceneLoader.cpp
+++ b/src/NullGameEngine/SceneLoader.cpp
@@ -17,7 +17,8 @@ namespace null {
     void SceneLoader::loadSceneFromFile(std::filesystem::path) {
         
         // todo this should be done in a scene file
-        auto newScene = std::make_unique<Scene>();
+        auto newScene = std::make_shared<Scene>();
+        newScene->self = newScene;
         auto& box2dWorld = newScene->getBox2dWorld();
 
         // this texture is not released on purpose, because it MUST exist for as long

--- a/src/NullGameEngine/SceneLoader.cpp
+++ b/src/NullGameEngine/SceneLoader.cpp
@@ -51,12 +51,19 @@ namespace null {
 
         boxObject->getRigidBody()->ApplyLinearImpulseToCenter(b2Vec2(15.0f, 0), true);
 
+        groundObject->addScript<ReloadSceneScript>(*groundObject);
+
         newScene->addGameObject(move(nullGameLogo));
         newScene->addGameObject(move(boxObject));
         newScene->addGameObject(move(groundObject));
 
         MainLoop::provideScene(move(newScene));
     };
+
+    void SceneLoader::changeScene(std::filesystem::path path) {
+        loadSceneFromFile(path);
+        throw SceneChangedException();
+    }
 
 }
 

--- a/src/Scripts/CMakeLists.txt
+++ b/src/Scripts/CMakeLists.txt
@@ -14,6 +14,8 @@ set(SRC
     ${INCROOT}/ClockedScript.hpp
     ${SRCROOT}/ExampleClockedScript.cpp
     ${INCROOT}/ExampleClockedScript.hpp
+    ${SRCROOT}/ReloadSceneScript.cpp
+    ${INCROOT}/ReloadSceneScript.hpp
     )
 
 add_library(scripts STATIC ${SRC})

--- a/src/Scripts/ReloadSceneScript.cpp
+++ b/src/Scripts/ReloadSceneScript.cpp
@@ -1,0 +1,22 @@
+#include <ReloadSceneScript.hpp>
+
+#include <MainLoop.hpp>
+#include <SceneLoader.hpp>
+
+namespace null {
+
+    ReloadSceneScript::ReloadSceneScript(GameObject& gameObject)
+        : Script(gameObject) { }
+
+    void ReloadSceneScript::start() {
+
+    }
+
+    void ReloadSceneScript::update() {
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::R)) {
+            SceneLoader::changeScene("todo example");
+        }
+    }
+
+}
+


### PR DESCRIPTION
1. Пофиксил тот баг с тем, что когда сцена меняется (или, что то же, помирает), из-за rigidbody был npe
2. Поскольку теперь это стало возможным, написал скрипт, который рестартит сцену на R. Работает...

К сожалению, сам фикс какой-то кривоватый получился, на мой взгляд (возможно из-за того, что приходится отдавать в scene self руками, но это точно потом уйдет, когда будет сделана хорошая сериализация)
Если есть мысли на этот счет, пожалуйста, делись @p-vasilev 