### PR TITLE
Better protobuf cmake & misc cmake updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ target_link_libraries(NULL_LEVEL_CHOOSER
 
 set(applications NULL_GAME_SERVER NULL_LEVEL_CHOOSER NULL_GAME)
 if (WIN32)
-    if (NOT MSVC)
+    if (NOT DEFINED CMAKE_GENERATOR_PLATFORM)
         message(WARNING "Cannot know what arch is used. You may need to manually copy openal32.dll from extlibs/bin")
         else()
         if (${CMAKE_GENERATOR_PLATFORM} MATCHES "64")
@@ -91,21 +91,23 @@ if (WIN32)
         else()
             set(arch_dir "x86")
         endif()
-        message(STATUS "Choose arch ${arch_dir} from generator platform ${CMAKE_GENERATOR_PLATFORM}")
+        message(STATUS "Chose arch ${arch_dir} from generator platform '${CMAKE_GENERATOR_PLATFORM}'")
+        message(STATUS "Openal will be copied to out directory for you")
     endif()
 endif()
 
 foreach(target_app ${applications})
+    set(output_dir "${CMAKE_SOURCE_DIR}/out/")
     add_custom_command(
             TARGET ${target_app} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy  $<TARGET_FILE:${target_app}> ${CMAKE_SOURCE_DIR}/out
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${output_dir}
+            COMMAND ${CMAKE_COMMAND} -E copy  $<TARGET_FILE:${target_app}> ${output_dir}
             COMMENT "Copy artifact to out directory"
     )
-    if (WIN32 and MSVC)
-        message(STATUS "Openal will be copied to out directory for you")
+    if (DEFINED arch_dir)
         add_custom_command(
                 TARGET ${target_app} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/extlibs/bin/${arch_dir}/openal32.dll ${CMAKE_SOURCE_DIR}/out
+                COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/extlibs/bin/${arch_dir}/openal32.dll ${output_dir}
                 COMMENT "Copy proper dll to out directory"
         )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,23 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 project(NULL_GAME VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+option(NULL_BUILD_TESTS "Build tests for null-game" OFF)
+
 set(BUILD_SHARED_LIBS OFF)
+
+if(WIN32)
+    foreach(flag_var
+            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+            CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+        if(${flag_var} MATCHES "/MD")
+            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+        endif(${flag_var} MATCHES "/MD")
+    endforeach()
+endif()
 
 if (WIN32 AND MSVC)
     # https://github.com/protocolbuffers/protobuf/blob/main/cmake/README.md#notes-on-compiler-warnings
@@ -13,10 +25,13 @@ if (WIN32 AND MSVC)
     add_compile_options(/wd4251)
 endif ()
 
-include(cmake/libraries.txt)
+include(cmake/libraries.cmake)
 
 add_subdirectory(./src/)
-add_subdirectory(./test/)
+
+if (NULL_BUILD_TESTS)
+    add_subdirectory(./test/)
+endif ()
 
 add_executable(NULL_GAME main.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,3 +80,33 @@ target_link_libraries(NULL_LEVEL_CHOOSER
         sfml-system
         sfml-network
         )
+
+set(applications NULL_GAME_SERVER NULL_LEVEL_CHOOSER NULL_GAME)
+if (WIN32)
+    if (NOT MSVC)
+        message(WARNING "Cannot know what arch is used. You may need to manually copy openal32.dll from extlibs/bin")
+        else()
+        if (${CMAKE_GENERATOR_PLATFORM} MATCHES "64")
+            set(arch_dir "x64")
+        else()
+            set(arch_dir "x86")
+        endif()
+        message(STATUS "Choose arch ${arch_dir} from generator platform ${CMAKE_GENERATOR_PLATFORM}")
+    endif()
+endif()
+
+foreach(target_app ${applications})
+    add_custom_command(
+            TARGET ${target_app} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy  $<TARGET_FILE:${target_app}> ${CMAKE_SOURCE_DIR}/out
+            COMMENT "Copy artifact to out directory"
+    )
+    if (WIN32 and MSVC)
+        message(STATUS "Openal will be copied to out directory for you")
+        add_custom_command(
+                TARGET ${target_app} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/extlibs/bin/${arch_dir}/openal32.dll ${CMAKE_SOURCE_DIR}/out
+                COMMENT "Copy proper dll to out directory"
+        )
+    endif()
+endforeach()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Buidling
 
-Debian-like OS: `sudo apt-get install build-essential protobuf-compiler xorg-dev libudev-dev libvorbis-dev`
+Debian-like OS: `sudo apt-get install build-essential protobuf-compiler xorg-dev libudev-dev libvorbis-dev libalut-dev libflac-dev`
 
 ```
 mkdir build

--- a/cmake/libraries.cmake
+++ b/cmake/libraries.cmake
@@ -14,10 +14,10 @@ make_dependency_available(
         GIT_TAG yaml-cpp-0.6.3
 )
 
-make_dependency_available(
-                googletest
-                URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
-)
+#make_dependency_available(
+#                googletest
+#                URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+#)
 if (WIN32)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 endif (WIN32)
@@ -40,3 +40,17 @@ make_dependency_available(
         GIT_REPOSITORY https://github.com/erincatto/box2d.git
         GIT_TAG v2.4.1
 )
+
+make_dependency_available(
+        protobuf
+        GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
+        GIT_TAG        e842f3fe3ccb96f35478a218808d360300cf3552
+)
+
+# https://stackoverflow.com/questions/74844369/how-to-i-use-the-cmake-command-protobuf-generate-when-installing-protobuf-throug
+# Get source directory of the Protobuf
+FetchContent_GetProperties(protobuf SOURCE_DIR Protobuf_SOURCE_DIR)
+message(STATUS "Protobuf source dir: ${Protobuf_SOURCE_DIR}")
+# Include the script which defines 'protobuf_generate'
+include(${Protobuf_SOURCE_DIR}/cmake/protobuf-generate.cmake)
+#protobuf_generate(TARGET proto-stuff IMPORT_DIRS ${Protobuf_SOURCE_DIR}/src)

--- a/include/Network/server/GameServer.h
+++ b/include/Network/server/GameServer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <queue>
+#include <mutex>
 
 #include "SFML/Network.hpp"
 #include "NetClientCollector.h"

--- a/src/Network/CMakeLists.txt
+++ b/src/Network/CMakeLists.txt
@@ -3,23 +3,11 @@ cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-find_package(Protobuf REQUIRED)
 
 set(INCROOT ${PROJECT_SOURCE_DIR}/include/Network/)
 set(SRCROOT ${PROJECT_SOURCE_DIR}/src/Network/)
 
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-
-# http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
-if(MSVC AND protobuf_MSVC_STATIC_RUNTIME)
-    foreach(flag_var
-            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-            CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-        if(${flag_var} MATCHES "/MD")
-            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-        endif(${flag_var} MATCHES "/MD")
-    endforeach()
-endif()
 
 set(PROTO_SRC
         ${SRCROOT}/serialized/serverConfig.proto
@@ -48,7 +36,8 @@ add_library(proto-stuff STATIC ${PROTO_SRC})
 target_include_directories(proto-stuff
         PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
         )
-protobuf_generate(TARGET proto-stuff)
+
+protobuf_generate(TARGET proto-stuff PROTOC_OPTIONS -I ${Protobuf_SOURCE_DIR}/src)
 target_link_libraries(proto-stuff
         protobuf::libprotobuf
         )

--- a/src/Serialization/CMakeLists.txt
+++ b/src/Serialization/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-find_package(Protobuf REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
 if(MSVC AND protobuf_MSVC_STATIC_RUNTIME)


### PR DESCRIPTION
Several things were changed:

  - Windows build was fixed
  - Now project build does not require protobuf installed on system. Not even the compiler or proto-hedears are needed. Protobuf is built as dependency and the built protobuf compiler is used within project.
  - Handy things such as: build artifacts are automatically copied to /out. More than that, if MSVC is used as generator and architecture is provided explicitly (e.g. `cmake .. -A x64`) openal32.dll is copied to /out automatically, too.


из минусов могу отметить, что конфигурация проекта теперь занимает 1 210 103 420 часов. Но компиляция также стала занимать больше времени, поскольку все зависимости теперь собираем вручную

![image](https://user-images.githubusercontent.com/42515597/212959471-c2a3ce06-c77d-4628-a743-38380439d27e.png)
